### PR TITLE
Prerender root route

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,18 @@
-<script>
+<script lang="ts">
+	import type { PageData } from './$types';
+	export let data: PageData;
 	import Link from '$lib/components/Link.svelte';
+
 </script>
 
 <header class="container">
 	<h1>Log Thing</h1>
 </header>
-<main class="container">
-	<p><Link href="/templates">My templates</Link></p>
-</main>
+{#if data.shouldRenderShell}
+	<main class="container" aria-busy="true">
+	</main>
+{:else}
+	<main class="container">
+		<p><Link href="/templates">My templates</Link></p>
+	</main>
+{/if}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,0 +1,26 @@
+import type { PageLoad } from './$types';
+
+import { browser, building, dev } from '$app/environment';
+import { error } from '@sveltejs/kit';
+
+export const ssr = true;
+export const prerender = true;
+
+export const load: PageLoad = async () => {
+    if (building || (dev && !browser)) {
+        //Just show the loading state
+        return {
+            shouldRenderShell: true
+        }
+    }
+    else if (browser) {
+        //TODO: load root page data from Dexie
+        return { 
+            shouldRenderShell: false
+        }
+    }
+    else {
+        console.error("Root path loader was run on the server and not at build time")
+        error(500);
+    }
+};


### PR DESCRIPTION
Data for root route (which will come from Dexie) is not available at build or server, so we just render a loading state instead in that case.